### PR TITLE
bug fix, now compatible with Python 3.5.3

### DIFF
--- a/epi/views.py
+++ b/epi/views.py
@@ -148,4 +148,4 @@ def yt_api_call(path, part, id_type, id_value):
     with urlopen(data_url) as response:
         json_data = response.read()
 
-    return json.loads(json_data)
+    return json.loads(json_data.decode('utf-8'))


### PR DESCRIPTION
fixed error"the JSON object must be str, not 'bytes' "
The software is now compatible with Python 3.5.3... at least on my server ;)